### PR TITLE
chore: Add the macOS runner to the matrix strategy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
 
     test:
         # The type of runner that the job will run on
-        runs-on: ubuntu-latest
+        runs-on: ${{ matrix.os }}
 
         needs:
             - matrix-prep-bazelversion
@@ -41,6 +41,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
+                os: [ubuntu-latest, macos-latest]
                 bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions) }}
                 folder:
                     - '.'


### PR DESCRIPTION
Adds the macOS runner to the matrix strategy of the test workflow job.