### PR TITLE
test: run rollup/tests:bundle as a build_test

### DIFF
--- a/rollup/tests/BUILD.bazel
+++ b/rollup/tests/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@aspect_rules_rollup//rollup:defs.bzl", "rollup")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
@@ -20,4 +21,9 @@ rollup(
     },
     node_modules = "//:node_modules",
     deps = [":lib"],
+)
+
+build_test(
+    name = "test",
+    targets = [":bundle"],
 )


### PR DESCRIPTION
Seems like this test was never actually being run.