### PR TITLE
chore: bump rules_js dep to 1.29.2 to pickup Windows fix

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,8 +12,9 @@ bazel_dep(name = "bazel_skylib", version = "1.3.0")
 # Need #397 to skip stardoc targets
 bazel_dep(name = "aspect_bazel_lib", version = "1.30.2")
 
-# Need attribute 'dev' in 'npm_package_store_internal' rule
-bazel_dep(name = "aspect_rules_js", version = "1.19.0")
+# 1.19.0: Need attribute 'dev' in 'npm_package_store_internal' rule
+# 1.29.2: Need Windows fix to disable fs patches
+bazel_dep(name = "aspect_rules_js", version = "1.29.2")
 bazel_dep(name = "rules_nodejs", version = "5.5.3")
 bazel_dep(name = "platforms", version = "0.0.5")
 

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -2,7 +2,7 @@
 
 bazel_dep(name = "aspect_rules_rollup", version = "0.0.0", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.3.0", dev_dependency = True)
-bazel_dep(name = "aspect_rules_js", version = "1.24.1", dev_dependency = True)
+bazel_dep(name = "aspect_rules_js", version = "1.29.2", dev_dependency = True)
 
 local_path_override(
     module_name = "aspect_rules_rollup",

--- a/rollup/dependencies.bzl
+++ b/rollup/dependencies.bzl
@@ -18,9 +18,9 @@ def rules_rollup_dependencies():
 
     http_archive(
         name = "aspect_rules_js",
-        sha256 = "4722264788b92aeca47bf108c5909d94720114d73739e3cff9f48a10b18ef8cd",
-        strip_prefix = "rules_js-1.25.0",
-        url = "https://github.com/aspect-build/rules_js/releases/download/v1.25.0/rules_js-v1.25.0.tar.gz",
+        sha256 = "7cb2d84b7d5220194627c9a0267ae599e357350e75ea4f28f337a25ca6219b83",
+        strip_prefix = "rules_js-1.29.2",
+        url = "https://github.com/aspect-build/rules_js/releases/download/v1.29.2/rules_js-v1.29.2.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Windows fix. BCR should be green now for Windows with this change.

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Covered by existing test cases
