### PR TITLE
chore: green up Windows CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,9 @@
 
 startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
 
+# Needed for rules_js
+common --enable_runfiles
+
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members
 # This needs to be last statement in this

--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -1,11 +1,9 @@
-# This file contains Bazel settings to apply on CI only.
-# It is referenced with a --bazelrc option in the call to bazel in ci.yaml
+# Directories caches by GitHub actions
+common --disk_cache=~/.cache/bazel-disk-cache
+common --repository_cache=~/.cache/bazel-repository-cache
 
 # Debug where options came from
 build --announce_rc
-# This directory is configured in GitHub actions to be persisted between runs.
-build --disk_cache=~/.cache/bazel
-build --repository_cache=~/.cache/bazel-repo
 # Don't rely on test logs being easily accessible from the test runner,
 # though it makes the log noisier.
 test --test_output=errors

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: CI
 
-# Controls when the action will run.
+# Controls when the action will run
 on:
     # Triggers the workflow on push or pull request events but only for the main branch
     push:
@@ -12,20 +12,111 @@ on:
     workflow_dispatch:
 
 concurrency:
-    # Cancel previous actions from the same PR: https://stackoverflow.com/a/72408109
-    group: concurrency-group::${{ github.workflow }}::${{ github.event.pull_request.number > 0 && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}
+    # Cancel previous actions from the same PR or branch except 'main' branch.
+    # See https://docs.github.com/en/actions/using-jobs/using-concurrency and https://docs.github.com/en/actions/learn-github-actions/contexts for more info.
+    group: concurrency-group::${{ github.workflow }}::${{ github.event.pull_request.number > 0 && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}${{ github.ref_name == 'main' && format('::{0}', github.run_id) || ''}}
     cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
+    # Prepares dynamic test matrix values
+    matrix-prep:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - id: bazel-version
+              name: Prepare 'bazel-version' matrix axis
+              run: |
+                  v=$(head -n 1 .bazelversion)
+                  m=${v::1}
+                  a=(
+                    "major:$m, version:\"$v\""
+                    "major:6, version:\"6.5.0\""
+                  )
+                  printf -v j '{%s},' "${a[@]}"
+                  echo "res=[${j%,}]" | tee -a $GITHUB_OUTPUT
+            - id: os
+              name: Prepare 'os' matrix axis
+              # Only run MacOS and Windows on main branch (not PRs) to minimize minutes (billed at 10X and 2X respectively)
+              # https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes
+              run: |
+                  a=( ubuntu )
+                  if [[ "${{ github.ref_name }}" == "main" ]] || [[ "${{ github.head_ref }}" == *"macos"* ]]; then
+                    a+=( macos )
+                  fi
+                  if [[ "${{ github.ref_name }}" == "main" ]] || [[ "${{ github.head_ref }}" == *"windows"* ]]; then
+                    a+=( windows )
+                  fi
+                  printf -v j '"%s",' "${a[@]}"
+                  echo "res=[${j%,}]" | tee -a $GITHUB_OUTPUT
+        outputs:
+            bazel-version: ${{ steps.bazel-version.outputs.res }}
+            os: ${{ steps.os.outputs.res }}
+
     test:
-        uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v6
-        with:
-            folders: |
-                [
-                  ".",
-                  "e2e/smoke"
-                ]
-            exclude: |
-                [
-                  {"folder": ".", "bzlmodEnabled": false}
-                ]
+        runs-on: ${{ matrix.os }}-latest
+        needs:
+            - matrix-prep
+        strategy:
+            fail-fast: false
+            matrix:
+                bazel-version: ${{ fromJSON(needs.matrix-prep.outputs.bazel-version) }}
+                bzlmod: [1, 0]
+                os: ${{ fromJSON(needs.matrix-prep.outputs.os) }}
+                folder:
+                    - '.'
+                    - 'e2e/smoke'
+                exclude:
+                    # Root workspace is only tested with bzlmod
+                    - folder: .
+                      bzlmod: 0
+                    # Don't test MacOS and Windows against secondary bazel version to minimize minutes (billed at 10X and 2X respectively)
+                    # https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes
+                    - os: macos
+                      bazel-version:
+                          major: 6
+                    - os: windows
+                      bazel-version:
+                          major: 6
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Mount bazel caches
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ~/.cache/bazel-disk-cache
+                      ~/.cache/bazel-repository-cache
+                      ~/.cache/xdg-cache
+                  key: bazel-cache-${{ matrix.bazel-version.version }}-${{ matrix.bzlmod }}-${{ matrix.os }}-${{ matrix.folder }}-${{ hashFiles('.bazelrc', '.bazelversion', '.bazeliskrc', '**/BUILD', '**/BUILD.bazel', '**/*.bzl', 'WORKSPACE', 'WORKSPACE.bazel', 'WORKSPACE.bzlmod', 'MODULE.bazel', 'MODULE.bazel.lock') }}
+                  restore-keys: bazel-cache-${{ matrix.bazel-version.version }}-${{ matrix.bzlmod }}-${{ matrix.os }}-${{ matrix.folder }}-
+
+            - name: Configure Bazel version
+              working-directory: ${{ matrix.folder }}
+              shell: bash
+              run: |
+                  # Overwrite the .bazelversion instead of using USE_BAZEL_VERSION so that Bazelisk
+                  # still bootstraps Aspect CLI from configuration in .bazeliskrc. Aspect CLI will
+                  # then use .bazelversion to determine which Bazel version to use.
+                  echo "${{ matrix.bazel-version.version }}" > .bazelversion
+
+            # TODO: remove this block once we have Aspect CLI Windows releases
+            - name: Don't use Aspect CLI on Windows
+              if: matrix.os == 'windows'
+              working-directory: ${{ matrix.folder }}
+              shell: bash
+              run: rm -f .bazeliskrc
+
+            - name: bazel test //...
+              working-directory: ${{ matrix.folder }}
+              shell: bash
+              run: |
+                  bazel \
+                    --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc \
+                    test \
+                    --test_tag_filters=-skip-on-bazel${{ matrix.bazel-version.major }} \
+                    --build_tag_filters=-skip-on-bazel${{ matrix.bazel-version.major }} \
+                    --enable_bzlmod=${{ matrix.bzlmod }} \
+                    //...
+              env:
+                  XDG_CACHE_HOME: ~/.cache/xdg-cache # bazelisk will download bazel to here


### PR DESCRIPTION
The bazel-contrib CI action `bazel-contrib/.github/.github/workflows/bazel.yaml@v6` fails on Windows since Aspect CLI doesn't currently have a Windows binary in its releases. We work-around this issue in our GHA ci.yaml. There are also other fine grained knobs we get from our the GHA ci.yaml we use for all our other rulesets that this PR brings in such as fine grained control of flags passed to bazel && a more flexible matrix generator that can include RBE in the future.