### PR TITLE
bazel: use short_path with entry_points

### DIFF
--- a/rollup/private/rollup.bzl
+++ b/rollup/private/rollup.bzl
@@ -147,7 +147,7 @@ def _impl(ctx):
     if ctx.attr.output_dir:
         output_sources.append(ctx.actions.declare_directory(ctx.label.name))
         for entry_point in entry_points:
-            args.add_joined([entry_point[1], entry_point[0]], join_with = "=")
+            args.add_joined([entry_point[1], entry_point[0].short_path], join_with = "=")
         args.add_all(["--output.dir", output_sources[0].short_path])
     else:
         args.add(entry_points[0][0])


### PR DESCRIPTION
Without this change bazel will pass the full qualified name like k8-fastbuild/bin/<package> which but rollup is being called from k8-fastbuild/bin so it can't resolve properly

I noticed the repo has not tests for multiple entry_point that's why it has gone unnoticed

### Changes are visible to end-users: yes

- I think end-users where not able to use the module before at all

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no (don't think so)
- Suggested release notes appear below: yes

- Manual testing; please provide instructions so we can reproduce: Tested into our monorepo, we have a ts_project that generates a bunch of js files, then we pass those as entry_points to rollup_bundle

If required I could try to setup a unit test
