### PR TITLE
Add Bazel 8 testing on BCR

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
     module_path: 'e2e/smoke'
     matrix:
-        bazel: ['7.x', '6.x']
+        bazel: ['8.x', '7.x', '6.x']
         platform: ['debian10', 'macos', 'ubuntu2004', 'windows']
     tasks:
         run_tests:


### PR DESCRIPTION
It's already known green, I patched this on the 2.0.1 release.
