### PR TITLE
expand user-supplied args

### DIFF
--- a/rollup/private/rollup.bzl
+++ b/rollup/private/rollup.bzl
@@ -143,7 +143,7 @@ def _impl(ctx):
     args = ctx.actions.args()
 
     # Add user specified arguments *before* rule supplied arguments
-    args.add_all(ctx.attr.args)
+    args.add_all([ctx.expand_location(args) for arg in ctx.attr.args])
 
     # List entry point argument first to save some argv space. Rollup doc says when provided as the
     # first options, it is equivalent to not prefix them with --input.


### PR DESCRIPTION
Changes the `rollup` rule to [expand location expressions](https://bazel.build/rules/lib/builtins/ctx#expand_location) in [user-supplied args](https://github.com/aspect-build/rules_rollup/blob/main/docs/rollup.md#rollup-args).

For example, as if this PR one could:

```starlark
rollup(
  name = "example",
  args = ["--configCustomField", "$(location :foo)"],
  srcs = [":foo"],
)

js_library(
  name = "foo",
  srcs = ["foo.js"],
)
```

Typical usages of rollup will not need this feature and will remain unaffected, however, rollup does support [custom command line arguments](https://github.com/rollup/rollup/issues/1662) and in those cases it can be useful to pass a build-time data file. Location expansion allows users to express this without hardcoding bazel file structures (see the above example).

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

I'm happy to add new tests, just let me know. The existing tests don't appear to check the contents of the bundle which would be necessary to fully test this feature. That said it's relatively straightforward so I could see this not requiring new tests.
